### PR TITLE
fix: Fix runtime crash when the testImpact directory is already created

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,14 +5,7 @@ build/
 !**/src/test/**/build/
 
 ### IntelliJ IDEA ###
-.idea/modules.xml
-.idea/jarRepositories.xml
-.idea/compiler.xml
-.idea/uiDesigner.xml
-.idea/workspace.xml
-.idea/misc.xml
-.idea/libraries/
-.idea/shelf/
+.idea/
 *.iws
 *.iml
 *.ipr
@@ -45,3 +38,5 @@ bin/
 
 ### Mac OS ###
 .DS_Store
+
+local.properties

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,9 +2,8 @@
 # Versions
 #-----------------
 [versions]
-jdkVersion = "8"
-kotlin = "1.8.21"
-kotlin-dsl = "4.0.14"
+jdkVersion = "21"
+kotlin-dsl = "5.1.2"
 
 #-----------------
 # Libraries

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Tue Nov 12 17:34:25 CET 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/test-impact-gradle-plugin/src/main/kotlin/dev/sunnyday/test/impact/plugin/TestImpactPlugin.kt
+++ b/test-impact-gradle-plugin/src/main/kotlin/dev/sunnyday/test/impact/plugin/TestImpactPlugin.kt
@@ -1,7 +1,7 @@
 package dev.sunnyday.test.impact.plugin
 
-import dev.sunnyday.test.impact.plugin.extension.TestImpactExtension
 import dev.sunnyday.test.impact.plugin.domain.graph.ProjectGraphResolver
+import dev.sunnyday.test.impact.plugin.extension.TestImpactExtension
 import dev.sunnyday.test.impact.plugin.task.testimpact.TestImpactTask
 import dev.sunnyday.test.impact.plugin.task.testimpact.TestImpactTaskOutput
 import org.gradle.api.Plugin
@@ -143,7 +143,7 @@ class TestImpactPlugin : Plugin<Project> {
         }
 
         private fun getTestImpactOutputFile(): File {
-            return File(target.buildDir, "tmp/testImpact/output.txt")
+            return File(target.layout.buildDirectory.get().asFile, "tmp/testImpact/output.txt")
         }
     }
 }

--- a/test-impact-gradle-plugin/src/main/kotlin/dev/sunnyday/test/impact/plugin/task/testimpact/TestImpactTaskOutput.kt
+++ b/test-impact-gradle-plugin/src/main/kotlin/dev/sunnyday/test/impact/plugin/task/testimpact/TestImpactTaskOutput.kt
@@ -12,7 +12,7 @@ internal class TestImpactTaskOutput(
 
     fun writeImpactGraph(graph: ImpactProjectGraph) {
         with(file) {
-            if (!exists() && !mkdirs()) {
+            if (!parentFile.exists() && !parentFile.mkdirs()) {
                 throw IOException("Can't create output file directory: $parentFile")
             }
 

--- a/test-impact-gradle-plugin/src/main/kotlin/dev/sunnyday/test/impact/plugin/task/testimpact/TestImpactTaskOutput.kt
+++ b/test-impact-gradle-plugin/src/main/kotlin/dev/sunnyday/test/impact/plugin/task/testimpact/TestImpactTaskOutput.kt
@@ -11,12 +11,14 @@ internal class TestImpactTaskOutput(
 ) {
 
     fun writeImpactGraph(graph: ImpactProjectGraph) {
-        if (!file.parentFile.mkdirs()) {
-            throw IOException("Can't create output file directory: ${file.parentFile}")
-        }
+        with(file) {
+            if (!exists() && !mkdirs()) {
+                throw IOException("Can't create output file directory: $parentFile")
+            }
 
-        ObjectOutputStream(file.outputStream()).use { stream ->
-            stream.writeObject(graph)
+            ObjectOutputStream(outputStream()).use { stream ->
+                stream.writeObject(graph)
+            }
         }
     }
 


### PR DESCRIPTION
`File.mkDirs()` is a tricky method :)